### PR TITLE
Switch to devcontainer spec

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -2,16 +2,18 @@ name: build-and-push
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "**.**.**"
+      - feature/**/**
+      - experiment/**/**/**
     paths:
       - src/**
       - .github/workflows/build-and-push.yml
   workflow_dispatch:
 
 env:
-  CACHE_TO_DEST: /tmp/.buildx-cache-new
   CACHE_FROM_SRC: /tmp/.buildx-cache
+  CACHE_TO_DEST: /tmp/.buildx-cache-new
 
 jobs:
   build-and-push:
@@ -63,90 +65,56 @@ jobs:
           files: |
             ${{ matrix.images.dockerfile }}
             ${{ matrix.images.additionalFilesToWatch }}
+            .github/workflows/build-and-push.yml
+
+      - name: Get latest tag
+        id: latest_tag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+        with:
+          fallback: tag-unavailable
 
       - name: Declare run state
         id: run_state
         run: |
           if [ ${{ steps.changed_files.outputs.any_modified }} == true ] || \
-            [ ${{ github.event_name }} == workflow_dispatch ];
+            [ ${{ github.event_name }} == workflow_dispatch ] || \
+            [ ${{ steps.latest_tag.outputs.tag }} != tag-unavailable ];
           then
             echo "::set-output name=run_docker_build::true"
             echo "::debug::Docker build will carry out as expected."
           else
             echo "::set-output name=run_docker_build::false"
-            echo "::debug::Docker build is cancelled as none of the watched files have been changed."
-            echo "Docker build is cancelled as none of the watched files have been changed."
+            echo "Docker build is cancelled as the required conditions for a run haven't been met"
           fi
 
-      - name: Get latest tag
+      - name: Variables
         if: steps.run_state.outputs.run_docker_build == 'true'
-        id: latest_tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
-        with:
-          fallback: 1.0.0
+        id: variables
+        run: |
+          repo_tag=${{ steps.latest_tag.outputs.tag }}
+          image_tag=${repo_tag//\//-}
+          image_ref=${{ matrix.images.containerName }}:$image_tag
+          echo "::set-output name=image_tag::$image_tag"
 
-        # FIX this will cause issues with minor or major version changes
-        # The semver created will end up being `2.0.1` if the tag is `2.0.0`
-        # maybe the action needs an `if` statement to ensure that this only
-        # only works if the patch version is `0`
-      - name: Get next minor version
+      - name: Build and push ${{ steps.variables.outputs.image_ref }}
         if: steps.run_state.outputs.run_docker_build == 'true'
-        id: semver
-        uses: WyriHaximus/github-action-next-semvers@v1
+        uses: utkusarioglu/devcontainer-build@main
         with:
-          version: ${{ steps.latest_tag.outputs.tag }}
-
-      - name: Set up Docker Buildx
-        if: steps.run_state.outputs.run_docker_build == 'true'
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to DockerHub
-        if: steps.run_state.outputs.run_docker_build == 'true'
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push ${{ matrix.images.containerName }}:${{ steps.semver.outputs.patch }}
-        if: steps.run_state.outputs.run_docker_build == 'true'
-        uses: docker/build-push-action@v2
-        id: docker-build
-        with:
-          context: .
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.images.containerName }}:${{ steps.semver.outputs.patch }}
-          file: ${{ matrix.images.dockerfile }}
-          push: ${{ github.ref == 'refs/heads/main' }}
-          cache-from: type=local,src=${{ env.CACHE_FROM_SRC }}
-          cache-to: type=local,mode=max,dest=${{ env.CACHE_TO_DEST }}
-          build-args: |
+          docker_hub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          docker_hub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+          image_name: ${{ matrix.images.containerName }}
+          image_tag: ${{ steps.variables.outputs.image_tag }}
+          dockerfile_path: ${{ matrix.images.dockerfile }}
+          build_args: |
             ROOT_PASS=${{ secrets.DOCKER_IMAGE_ROOT_PASS }}
             USERNAME=${{ matrix.images.username }}
             ENVIRONMENT_NAME=${{ matrix.images.environmentName }}
             ENVIRONMENT_CONFIG=${{ matrix.images.environmentConfigPath }}
             ADDITIONAL_APT_PACKAGES=${{ matrix.images.additionalAptPackages }}
-
-      - name: Image digest
-        if: steps.run_state.outputs.run_docker_build == 'true'
-        run: echo ${{ steps.docker-build.outputs.digest }}
-
-      - name: Set Docker Hub description
-        if: steps.run_state.outputs.run_docker_build == 'true'
-        uses: peter-evans/dockerhub-description@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.images.containerName }}
-          short-description: ${{ matrix.images.dockerShortDescription }}
-          readme-filepath: ${{ matrix.images.dockerReadmePath }}
-
-      - name: Move cache
-        run: |
-          rm -rf ${{ env.CACHE_FROM_SRC }}
-          if [ -d ${{ env.CACHE_FROM_SRC }} ];
-          then
-            mv ${{ env.CACHE_TO_DEST }} ${{ env.CACHE_FROM_SRC }}
-          fi
+          devcontainer_subfolder: src/${{ matrix.images.environmentName }}
+          devcontainer_run_cmd_path: /scripts/devcontainer-check.sh
+          docker_hub_repo_short_description: ${{ matrix.images.dockerShortDescription }}
+          docker_hub_repo_readme_file_path: ${{ matrix.images.dockerReadmePath }}
 
       - name: Telegram notifications
         if: always()

--- a/src/Dockerfile.conda.dev
+++ b/src/Dockerfile.conda.dev
@@ -23,22 +23,22 @@ RUN echo "root:$ROOT_PASS" | chpasswd
 RUN useradd -m $USERNAME
 USER $USERNAME
 
-# Conda is installed as $USERNAME
+# Conda is deliberately installed as user: $USERNAME
 COPY $ENVIRONMENT_CONFIG /environment.yml
 RUN conda env create --file /environment.yml
 
 
 # Gists
 ADD --chown=$USERNAME:$GROUP \
-  https://gist.githubusercontent.com/utkusarioglu/2d4be44dc7707afccd540ad99ba385e6/raw/3eb6693a91b1aa5b3863d087de1d189b72eeeec8/create-env-example.sh \
+  https://gist.githubusercontent.com/utkusarioglu/2d4be44dc7707afccd540ad99ba385e6/raw/create-env-example.sh \
   /scripts/create-env-example.sh
 
 ADD --chown=$USERNAME:$GROUP \
-  https://gist.githubusercontent.com/utkusarioglu/3523b00578807d63b05399fe57a4b2a7/raw/7df99dbbeb8ee4d14396be043aef4fbf8fb42ce5/.bashrc \
+  https://gist.githubusercontent.com/utkusarioglu/3523b00578807d63b05399fe57a4b2a7/raw/.bashrc \
   /home/$USERNAME/.bashrc
 
 ADD --chown=$USERNAME:$GROUP \
-  https://gist.githubusercontent.com/utkusarioglu/d5c216c744460c45bf6260d0de4131b4/raw/d227102e3630a93f8eafcb4d2a5a053d2ae04415/.inputrc \
+  https://gist.githubusercontent.com/utkusarioglu/d5c216c744460c45bf6260d0de4131b4/raw/.inputrc \
   /home/$USERNAME/.inputrc
 RUN chmod +x \
   /scripts/create-env-example.sh \
@@ -50,3 +50,5 @@ ENV SHELL /bin/bash
 # Pushing into `.bashrc` for environment selection
 # This line is unique for all containers
 RUN echo "source activate $ENVIRONMENT_NAME" >> /home/$USERNAME/.bashrc
+
+COPY src/${ENVIRONMENT_NAME}/scripts /scripts

--- a/src/econ/.devcontainer/devcontainer.json
+++ b/src/econ/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "image": "${localEnv:IMAGE_NAME}:${localEnv:IMAGE_TAG}",
+  "features": {
+    "github-cli": "latest",
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    }
+  }
+}

--- a/src/econ/scripts/devcontainer-check.sh
+++ b/src/econ/scripts/devcontainer-check.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+required_packages="gh python vim git"
+
+for exec in $required_packages;
+do
+  if [ -z "$(which $exec)" ];
+  then
+    echo "Error: $exec is not available inside the container"
+    exit 1
+  fi
+done

--- a/src/math/.devcontainer/devcontainer.json
+++ b/src/math/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "image": "${localEnv:IMAGE_NAME}:${localEnv:IMAGE_TAG}",
+  "features": {
+    "github-cli": "latest",
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    }
+  }
+}

--- a/src/math/scripts/devcontainer-check.sh
+++ b/src/math/scripts/devcontainer-check.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+required_packages="gh python vim git"
+
+for exec in $required_packages;
+do
+  if [ -z "$(which $exec)" ];
+  then
+    echo "Error: $exec is not available inside the container"
+    exit 1
+  fi
+done

--- a/src/music/.devcontainer/devcontainer.json
+++ b/src/music/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "image": "${localEnv:IMAGE_NAME}:${localEnv:IMAGE_TAG}",
+  "features": {
+    "github-cli": "latest",
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    }
+  }
+}

--- a/src/music/scripts/devcontainer-check.sh
+++ b/src/music/scripts/devcontainer-check.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+required_packages="gh python vim git"
+
+for exec in $required_packages;
+do
+  if [ -z "$(which $exec)" ];
+  then
+    echo "Error: $exec is not available inside the container"
+    exit 1
+  fi
+done


### PR DESCRIPTION
- Add `.devcontainer/devcontainer.json` to all conda environments.
  The spec file installs github cli and ssh support to the
  devcontainers.
- Alter `Dockerfile.conda.dev`:
  - Alter comment on line 26 to make it clearer.
  - Alter download url for gists at 33, 37, 41 for them to download
    the latest version of the gists every time. This is done to reduce
    maintenance burden.
  - Add step for copying the devcontainer checker script file to the
    container. This file is used by CI to run inside the newly created
    devcontainer to check whether everything works as expected.
- Add `devcontainer-check.sh` script to all the environment. This is
  the devcontainer checker mentioned in the previous bullet.
- Alter `build-and-push.sh`:
  - Set tags for triggering runs
  - Remove branches from triggers
  - Add the workflow file itself to the `changed_files` checker at
    ln 68.
  - Add tag checking to `run_state` step to ensure that the run has a
    tag.
  - Add action `utkusarioglu/devcontainer-build@main` among the steps
    to build a devcontainer that is compliant with the specs.
  - Remove steps that are rendered obsolete by the previous bullet.
