### PR TITLE
Feat: Replace vim with nvim

### DIFF
--- a/src/Dockerfile.conda.dev
+++ b/src/Dockerfile.conda.dev
@@ -1,10 +1,10 @@
 FROM continuumio/miniconda3
 
-ARG ROOT_PASS=
-ARG USERNAME=
-ARG ENVIRONMENT_NAME= 
-ARG ENVIRONMENT_CONFIG=
-ARG ADDITIONAL_APT_PACKAGES=
+ARG ROOT_PASS
+ARG USERNAME
+ARG ENVIRONMENT_NAME 
+ARG ENVIRONMENT_CONFIG
+ARG ADDITIONAL_APT_PACKAGES
 
 RUN for arg in ROOT_PASS USERNAME ENVIRONMENT_NAME ENVIRONMENT_CONFIG; \
   do \
@@ -15,8 +15,15 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update && \
   apt-get upgrade -y && \
   apt-get install -y \
-  vim \
   $ADDITIONAL_APT_PACKAGES
+
+# Neovim requires manual retrieval of the latest version
+# as the apt package is quite old
+RUN wget https://github.com/neovim/neovim/releases/download/v0.8.0/nvim-linux64.deb \
+  -O /neovim.deb
+RUN apt install -y /neovim.deb 
+RUN rm /neovim.deb
+ENV EDITOR=nvim
 
 RUN echo "root:$ROOT_PASS" | chpasswd
 

--- a/src/econ/scripts/devcontainer-check.sh
+++ b/src/econ/scripts/devcontainer-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-required_packages="gh python vim git"
+required_packages="gh python nvim git"
 
 for exec in $required_packages;
 do

--- a/src/math/scripts/devcontainer-check.sh
+++ b/src/math/scripts/devcontainer-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-required_packages="gh python vim git"
+required_packages="gh python nvim git"
 
 for exec in $required_packages;
 do

--- a/src/music/scripts/devcontainer-check.sh
+++ b/src/music/scripts/devcontainer-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-required_packages="gh python vim git"
+required_packages="gh python nvim git"
 
 for exec in $required_packages;
 do


### PR DESCRIPTION
- Replace vim with nvim in devcontainers. This is done because nvim
  also acts as a server for vscode.
- Alter `devcontainer-checks.sh` for each conda package to ensure
  that nvim is present in built images.
