### PR TITLE
Fix: vscode extensions folders

### DIFF
--- a/src/Dockerfile.conda.dev
+++ b/src/Dockerfile.conda.dev
@@ -5,6 +5,7 @@ ARG USERNAME
 ARG ENVIRONMENT_NAME 
 ARG ENVIRONMENT_CONFIG
 ARG ADDITIONAL_APT_PACKAGES
+ARG HOME=/home/$USERNAME
 
 RUN for arg in ROOT_PASS USERNAME ENVIRONMENT_NAME ENVIRONMENT_CONFIG; \
   do \
@@ -42,15 +43,18 @@ ADD --chown=$USERNAME:$GROUP \
 
 ADD --chown=$USERNAME:$GROUP \
   https://gist.githubusercontent.com/utkusarioglu/3523b00578807d63b05399fe57a4b2a7/raw/.bashrc \
-  /home/$USERNAME/.bashrc
+  $HOME/.bashrc
 
 ADD --chown=$USERNAME:$GROUP \
   https://gist.githubusercontent.com/utkusarioglu/d5c216c744460c45bf6260d0de4131b4/raw/.inputrc \
-  /home/$USERNAME/.inputrc
+  $HOME/.inputrc
 RUN chmod +x \
   /scripts/create-env-example.sh \
-  /home/$USERNAME/.bashrc \
-  /home/$USERNAME/.inputrc
+  $HOME/.bashrc \
+  $HOME/.inputrc
+
+RUN mkdir -p $HOME/.vscode-server/extensions
+RUN mkdir -p $HOME/.vscode-server-insiders/extensions
 
 ENV PATH "/opt/conda/envs/$ENVIRONMENT_NAME/bin:$PATH"
 ENV SHELL /bin/bash


### PR DESCRIPTION
- Create vscode-server extensions folders inside the container. This is
  done because of docker's inability to handle thes folders while
  running a non-root container.
