### PR TITLE
Feat: Add default environment and watchdog to py

### DIFF
--- a/src/Dockerfile.python.dev
+++ b/src/Dockerfile.python.dev
@@ -55,3 +55,7 @@ RUN mkdir -p $HOME/.vscode-server/extensions
 RUN mkdir -p $HOME/.vscode-server-insiders/extensions
 
 COPY src/${ENVIRONMENT_NAME}/scripts /scripts
+
+RUN python -m venv ~/venv/main
+RUN pip install watchdog
+RUN echo "source ~/venv/main/bin/activate" >> ~/.bashrc


### PR DESCRIPTION
- Add a default environment named `main` to python devcontainer.
- Add watchdog (watchmedo) for code change monitoring to python
  devcontainer.
