### PR TITLE
Feat: Add jq to containers

### DIFF
--- a/src/Dockerfile.conda.dev
+++ b/src/Dockerfile.conda.dev
@@ -16,6 +16,7 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update && \
   apt-get upgrade -y && \
   apt-get install -y \
+  jq \
   $ADDITIONAL_APT_PACKAGES
 
 # Neovim requires manual retrieval of the latest version

--- a/src/Dockerfile.python.dev
+++ b/src/Dockerfile.python.dev
@@ -16,6 +16,7 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update && \
   apt-get upgrade -y && \
   apt-get install -y \
+  jq \
   $ADDITIONAL_APT_PACKAGES
 
 # Neovim requires manual retrieval of the latest version


### PR DESCRIPTION
- jq is required by some tools, such as the repo-updater. For this
  reason, it's advisable to have it in the devcontainer.
