### PR TITLE
Feat: Include pytest in all devcontainers

### DIFF
--- a/src/Dockerfile.python.dev
+++ b/src/Dockerfile.python.dev
@@ -60,3 +60,5 @@ COPY src/${ENVIRONMENT_NAME}/scripts /scripts
 RUN python -m venv ~/venv/main
 RUN pip install watchdog
 RUN echo "source ~/venv/main/bin/activate" >> ~/.bashrc
+
+RUN pip install pytest

--- a/src/econ/environment.econ.yml
+++ b/src/econ/environment.econ.yml
@@ -1,15 +1,16 @@
 name: econ
 channels:
-  - conda-forge
-  - anaconda
+  - defaults
 dependencies:
-  - jupyter
-  - numpy
-  - pandas
-  - scipy
-  - xlsxwriter
-  - python-dotenv
-  - matplotlib
-  - squarify
-  - openpyxl
-  - requests
+  - anaconda::jupyter
+  - anaconda::numpy
+
+  - conda-forge::matplotlib
+  - conda-forge::openpyxl
+  - conda-forge::pandas
+  - conda-forge::pytest
+  - conda-forge::python-dotenv
+  - conda-forge::requests
+  - conda-forge::scipy
+  - conda-forge::squarify
+  - conda-forge::xlsxwriter

--- a/src/math/environment.math.yml
+++ b/src/math/environment.math.yml
@@ -1,12 +1,14 @@
 name: math
-channels: 
-  - anaconda
+channels:
+  - default
 dependencies:
-  - jupyter
-  - numpy
-  - pandas
-  - scipy
-  - xlsxwriter
-  - matplotlib
-  - scipy
-  - sympy
+  - anaconda::jupyter
+  - anaconda::numpy
+
+  - conda-forge::matplotlib
+  - conda-forge::pandas
+  - conda-forge::pytest
+  - conda-forge::scipy
+  - conda-forge::scipy
+  - conda-forge::sympy
+  - conda-forge::xlsxwriter

--- a/src/music/environment.music.yml
+++ b/src/music/environment.music.yml
@@ -3,8 +3,10 @@ channels:
   - defaults
 dependencies:
   - anaconda::jupyter
+
   - conda-forge::music21
   - conda-forge::matplotlib
+  - conda-forge::pytest
 # These may be enabled later, depending on need
 # - anaconda::numpy
 # - anaconda::scipy


### PR DESCRIPTION
- Include pytest in all conda and python devcontainers.
- Close #1 by updating conda environment files to include dependency
  channels explicitly.
