### PR TITLE
Feat: Add elam to conda

### DIFF
--- a/src/Dockerfile.conda.dev
+++ b/src/Dockerfile.conda.dev
@@ -15,6 +15,9 @@ ARG NVIM_VERSION=v0.8.3
 ARG MAMBA_ROOT_PREFIX=/opt/conda
 ARG ELAM_ABSPATH="$HOME/elam"
 
+ARG VENV_NAME=main
+ARG VENV_PATH="${HOME}/venv/${VENV_NAME}"
+
 USER root
 
 RUN usermod -l $USERNAME mambauser
@@ -106,8 +109,11 @@ RUN echo "alias elam=$ELAM_ABSPATH/elam.sh" >> $HOME/.bash_aliases
 ENV PATH "$MAMBA_ROOT_PREFIX/envs/$ENVIRONMENT_NAME/bin:$PATH"
 ENV SHELL /bin/bash
 
+RUN python -m venv ${VENV_PATH}
+RUN echo "source ${VENV_PATH}/bin/activate" >> ~/.bashrc
 COPY "src/$DEVCONTAINER_SUBFOLDER/requirements.txt" "/requirements.txt"
-RUN pip install -r "/requirements.txt"
+RUN source ${VENV_PATH}/bin/activate && \
+  pip install --require-virtualenv -r "/requirements.txt"
 
 COPY "${SCRIPTS_PATH}" /scripts
 

--- a/src/Dockerfile.python.dev
+++ b/src/Dockerfile.python.dev
@@ -24,6 +24,7 @@ RUN apt-get update && \
   apt-get upgrade -y && \
   apt-get install -y \
   jq \
+  ncurses-bin \
   $ADDITIONAL_APT_PACKAGES
 
 # Neovim requires manual retrieval of the latest version


### PR DESCRIPTION
- Add elam to conda containers
- Fix pip libraries being installed to default python environment. Now
  they are installed in `main` as they should be.
- Install ncurses-bin to python devcontainer.
