### PR TITLE
Fix: Environment management in Conda devcontainers

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -46,7 +46,7 @@ jobs:
           - enabled: true
             dockerfile: src/Dockerfile.conda.dev
             containerName: conda-econ-devcontainer
-            username: econ
+            username: default
             group: micromamba
             environmentName: default
             scriptsPath: src/econ/scripts
@@ -64,7 +64,7 @@ jobs:
           - enabled: true
             dockerfile: src/Dockerfile.conda.dev
             containerName: conda-math-devcontainer
-            username: math
+            username: default
             group: micromamba
             environmentName: default
             scriptsPath: src/math/scripts
@@ -83,7 +83,7 @@ jobs:
           - enabled: true
             dockerfile: src/Dockerfile.conda.dev
             containerName: conda-music-devcontainer
-            username: music
+            username: default
             group: micromamba
             environmentName: default
             scriptsPath: src/music/scripts
@@ -100,13 +100,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
       - name: Get changed files
         id: changed_files
-        uses: tj-actions/changed-files@v25
+        uses: tj-actions/changed-files@v39.0.2
         with:
           files: |
             ${{ matrix.images.dockerfile }}
@@ -140,8 +140,20 @@ jobs:
           echo "Any modified: $any_modified"
           echo "Event name: $event_name" 
 
+      # - name: Free Disk Space (Ubuntu)
+      #   # if: steps.run_state.outputs.run_docker_build == 'true'
+      #   uses: jlumbroso/free-disk-space@main
+      #   with:
+      #     tool-cache: false
+      #     android: true
+      #     dotnet: true
+      #     haskell: true
+      #     large-packages: true
+      #     docker-images: true
+      #     swap-storage: true
+
       - name: Variables
-        if: steps.run_state.outputs.run_docker_build == 'true'
+        # if: steps.run_state.outputs.run_docker_build == 'true'
         id: variables
         run: |
           repo_tag=${{ github.ref_name }}
@@ -150,7 +162,7 @@ jobs:
           echo "image_tag=$image_tag" >> $GITHUB_OUTPUT
 
       - name: Build and push ${{ steps.variables.outputs.image_ref }}
-        if: steps.run_state.outputs.run_docker_build == 'true'
+        # if: steps.run_state.outputs.run_docker_build == 'true'
         uses: utkusarioglu/devcontainer-build@main
         with:
           docker_hub_username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/src/Dockerfile.conda.dev
+++ b/src/Dockerfile.conda.dev
@@ -15,9 +15,6 @@ ARG NVIM_VERSION=v0.8.3
 ARG MAMBA_ROOT_PREFIX=/opt/conda
 ARG ELAM_ABSPATH="$HOME/elam"
 
-ARG VENV_NAME=main
-ARG VENV_PATH="${HOME}/venv/${VENV_NAME}"
-
 USER root
 
 RUN usermod -l $USERNAME mambauser
@@ -26,7 +23,6 @@ RUN groupmod -n $GROUP mambauser
 RUN ls -al "/home"
 RUN echo "home: $HOME"
 ENV HOME="/home/$USERNAME"
-RUN echo "home 2: $HOME"
 RUN rm -rf "/home/mambauser"
 
 SHELL ["/bin/bash", "-c"]
@@ -104,18 +100,22 @@ RUN chmod +x \
 
 # Elam
 RUN git clone https://github.com/utkusarioglu/elam.git $ELAM_ABSPATH
-RUN echo "alias elam=$ELAM_ABSPATH/elam.sh" >> $HOME/.bash_aliases
+RUN echo "alias elam=$ELAM_ABSPATH/elam.sh" >> "${HOME}/.bash_aliases"
+
+# Micromamba Alias
+RUN echo 'alias mm=micromamba' >> "${HOME}/.bash_aliases"
 
 ENV PATH "$MAMBA_ROOT_PREFIX/envs/$ENVIRONMENT_NAME/bin:$PATH"
 ENV SHELL /bin/bash
-
-RUN python -m venv ${VENV_PATH}
-RUN echo "source ${VENV_PATH}/bin/activate" >> ~/.bashrc
-COPY "src/$DEVCONTAINER_SUBFOLDER/requirements.txt" "/requirements.txt"
-RUN source ${VENV_PATH}/bin/activate && \
-  pip install --require-virtualenv -r "/requirements.txt"
 
 COPY "${SCRIPTS_PATH}" /scripts
 
 # Pushing into `.bashrc` for environment selection
 RUN echo "eval \"\$(micromamba shell hook --shell=bash)\" && micromamba activate $ENVIRONMENT_NAME" >> ~/.bashrc
+
+SHELL ["/bin/bash", "--login", "-c"]
+COPY "src/$DEVCONTAINER_SUBFOLDER/requirements.txt" "/requirements.txt"
+RUN pip install -r "/requirements.txt"
+
+RUN pip list -v
+RUN micromamba list

--- a/src/econ/.devcontainer/devcontainer.json
+++ b/src/econ/.devcontainer/devcontainer.json
@@ -2,9 +2,6 @@
   "image": "${localEnv:IMAGE_NAME}:${localEnv:IMAGE_TAG}",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers/features/sshd:1": {
-      "version": "latest"
-    }
+    "ghcr.io/devcontainers/features/git:1": {}
   }
 }

--- a/src/econ/DOCKER_README.econ.md
+++ b/src/econ/DOCKER_README.econ.md
@@ -14,4 +14,4 @@ Devcontainer image for handling economics workloads.
 - squarify
 - openpyxl
 - requests
-- vim
+- nvim

--- a/src/econ/environment.econ.yml
+++ b/src/econ/environment.econ.yml
@@ -10,7 +10,6 @@ dependencies:
   - conda-forge::openpyxl=3.1.1
   - conda-forge::requests=2.28.2
   - anaconda::psycopg2=2.9.3
-  - conda-forge::sqlalchemy=1.4.46
   - conda-forge::cmasher=1.6.3
   - conda-forge::quantecon=0.5.2
   - conda-forge::scikit-learn=1.2.2

--- a/src/math/.devcontainer/devcontainer.json
+++ b/src/math/.devcontainer/devcontainer.json
@@ -2,9 +2,6 @@
   "image": "${localEnv:IMAGE_NAME}:${localEnv:IMAGE_TAG}",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers/features/sshd:1": {
-      "version": "latest"
-    }
+    "ghcr.io/devcontainers/features/git:1": {}
   }
 }

--- a/src/math/DOCKER_README.math.md
+++ b/src/math/DOCKER_README.math.md
@@ -12,4 +12,4 @@ Devcontainer image for handling mathematics workloads.
 - matplotlib
 - scipy
 - sympy
-- vim
+- nvim

--- a/src/music/.devcontainer/devcontainer.json
+++ b/src/music/.devcontainer/devcontainer.json
@@ -2,9 +2,6 @@
   "image": "${localEnv:IMAGE_NAME}:${localEnv:IMAGE_TAG}",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers/features/sshd:1": {
-      "version": "latest"
-    }
+    "ghcr.io/devcontainers/features/git:1": {}
   }
 }

--- a/src/music/DOCKER_README.music.md
+++ b/src/music/DOCKER_README.music.md
@@ -8,4 +8,4 @@ Devcontainer image for handling music workloads.
 - music21
 - matplotlib
 - musescore 3
-- vim
+- nvim

--- a/src/python/.devcontainer/devcontainer.json
+++ b/src/python/.devcontainer/devcontainer.json
@@ -2,9 +2,6 @@
   "image": "${localEnv:IMAGE_NAME}:${localEnv:IMAGE_TAG}",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers/features/sshd:1": {
-      "version": "latest"
-    }
+    "ghcr.io/devcontainers/features/git:1": {}
   }
 }

--- a/src/python/DOCKER_README.python.md
+++ b/src/python/DOCKER_README.python.md
@@ -4,4 +4,10 @@ Devcontainer image for handling python workloads.
 
 ## Features
 
+- black
+- watchdog
+- pytest
+- black
+- flake8
+- python-dotenv
 - nvim


### PR DESCRIPTION
- Fix pip & micromamba related environment management issues. Now pip is
  a part of micromamba environment. Any package installed through pip is
  installed inside the `default` micromamba environment. Pip doesn't
  have an environment of its own.
- create alias `mm` for micromamba in conda container to make the
  command easier to use.
- Remove ssh devcontainer feature in all containers
